### PR TITLE
Q10: distribute load to avoid skewed data

### DIFF
--- a/engines/hive/queries/q10/q10.sql
+++ b/engines/hive/queries/q10/q10.sql
@@ -27,7 +27,10 @@ ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
 STORED AS ${env:BIG_BENCH_hive_default_fileformat_result_table} LOCATION '${hiveconf:RESULT_DIR}';
 
 -- the real query part
+set hive.exec.reducers.bytes.per.reducer=20000000;
 INSERT INTO TABLE ${hiveconf:RESULT_TABLE}
 SELECT extract_sentiment(pr_item_sk,pr_review_content) AS (pr_item_sk, review_sentence, sentiment, sentiment_word)
-FROM product_reviews
+FROM (
+  SELECT pr_item_sk,pr_review_content FROM product_reviews DISTRIBUTE BY length(pr_review_content)
+) pr
 ;


### PR DESCRIPTION
q10 is a simple query to extract words from the product_reviews table to perform sentiment analysis. As the data is generated ramdonly, cases are that some map tasks have to process far more review contents. This caused typical data skew issue and the query time is determined by the slowest task.
This improvement exploits MR to distribute the skewed data across many reduce tasks to balance the load, and finally enhance the query performance (about 50% improvement).