### PR TITLE
Fix empty result tables / null values

### DIFF
--- a/engines/hive/conf/queryParameters.sql
+++ b/engines/hive/conf/queryParameters.sql
@@ -40,7 +40,7 @@ set q02_limit=300000;
 -------- Q03 -----------
 -- no results-check reduce script
 set q03_days_before_purchase=10;
-set q03_purchased_item_IN=16891;
+set q03_purchased_item_IN=5809;
 --see q1 for categories
 set q03_purchased_item_category_IN=1,2,3,4,5; 
 

--- a/engines/hive/conf/queryParameters.sql
+++ b/engines/hive/conf/queryParameters.sql
@@ -173,7 +173,7 @@ set q19_store_return_limit=100;
 
 -------- Q21 -----------
 --store_sales/returns web_sales/returns date
-set q21_year=2001;
+set q21_year=2003;
 set q21_month=4;
 
 -------- Q22 -----------

--- a/engines/hive/conf/queryParameters.sql
+++ b/engines/hive/conf/queryParameters.sql
@@ -151,11 +151,11 @@ set q15_store_sk=10;
 set q16_date=2001-03-16;
 
 -------- Q17 -----------
-set q17_gmt_offset=-7;
+set q17_gmt_offset=-5;
 --store_sales date
 set q17_year=2001; 
 set q17_month=12;
-set q17_i_category_IN='Jewelry';
+set q17_i_category_IN='Books', 'Music';
 
 -------- Q18 -----------
 -- store_sales date range

--- a/engines/hive/queries/q14/q14.sql
+++ b/engines/hive/queries/q14/q14.sql
@@ -39,8 +39,8 @@ JOIN (
   JOIN household_demographics hd ON ws.ws_ship_hdemo_sk = hd.hd_demo_sk
   AND hd.hd_dep_count = ${hiveconf:q14_dependents}
   JOIN time_dim td ON  td.t_time_sk =ws.ws_sold_time_sk
-  AND td.t_hour > ${hiveconf:q14_evening_startHour}
-  AND td.t_hour < ${hiveconf:q14_evening_endHour}
+  AND td.t_hour >= ${hiveconf:q14_evening_startHour}
+  AND td.t_hour <= ${hiveconf:q14_evening_endHour}
   JOIN web_page wp ON wp.wp_web_page_sk = ws.ws_web_page_sk
   AND wp.wp_char_count >= ${hiveconf:q14_content_len_min}
   AND wp.wp_char_count <= ${hiveconf:q14_content_len_max}


### PR DESCRIPTION
There are already a few issues open regarding empty result tables / null values in result tables.

This pull requests includes adjustments to eliminate empty result sets. My scale factor is 1GB/10GB due to quick result validation. However, issues with empty result sets also exists for bigger scale factors.

**Query 3**
Currently there are results for higher scale factors. I just changed purchased item to another value so that there is already a result for scale factor 1.

**Query 14** (https://github.com/intel-hadoop/Big-Bench/issues/13)
Match for the evening time range absolutely not possible, because comparative operators are wrong. Changed these operators. 

**Query 17** (https://github.com/intel-hadoop/Big-Bench/issues/14)
Calculation results in null values due to no results in sub queries. Changed gmt offset and category to sensible values. I also defined two/multiple categories, because query description says "...certain categories...".

**Query 21**
Executing this query with scale factor 1000 returns one record. However, I changed the year constant, so that there is already a result for scale factor 10.

**Query 24** (https://github.com/intel-hadoop/Big-Bench/issues/18)
NULL values for one product (i_item_sk=17) is fine for me. This is related to division by zero in finale statement (determined quantity of product is zero). Seems to be a valid case. Product could be changed so that there is a higher quantity. However, I think this is not essential.

Table with current results and results after applying this pull request:

Query | Row count (current) | Sample row (current) | Row count (fixed) | Sample row (fixed)
------------ | ------------- | ------------- | ------------- | -------------
3 (sf 1)  | 0 |   | 2 | 4359 5809 1
14 (sf 1)  | 1 | NULL | 1 | 0.7439024390243902
17 (sf 1)  | 1 | NULL NULL NULL | 1 | 1748943.9299999962 3222985.570000002 54.264714874289524
21 (sf 10)  | 0 |   | 1 | AAAAAAAAAAAACVGX ironic somas could have to grow quietly sly frays. gifts will have to unwind ironically permanent ca AAAAAAAAAAAAAABG bar 15 9 100